### PR TITLE
added in model_id as a passed parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ This is an open source Eleven Labs NodeJS package for converting text to speech 
 
 | <div style="width:290px">Function</div> | Parameters                                                            | Endpoint                              |
 | --------------------------------------- | --------------------------------------------------------------------- | ------------------------------------- |
-|  `textToSpeech`                         | (apiKey, voiceID, fileName, textInput, stability, similarityBoost)    | `/v1/text-to-speech/{voice_id}`       |
-|  `textToSpeechStream`                   | (apiKey, voiceID, textInput, stability, similarityBoost)              | `/v1/text-to-speech/{voice_id}/stream`|
+|  `textToSpeech`                         | (apiKey, voiceID, fileName, textInput, stability, similarityBoost, modelId)    | `/v1/text-to-speech/{voice_id}`       |
+|  `textToSpeechStream`                   | (apiKey, voiceID, textInput, stability, similarityBoost, modelId)              | `/v1/text-to-speech/{voice_id}/stream`|
 |  `getVoices`                            | (apiKey)                                                              | `/v1/voices`                          |
 |  `getDefaultVoiceSettings`              | N/A                                                                   | `/v1/voices/settings/default`         |
 |  `getVoiceSettings`                     | (apiKey, voiceID)                                                     | `/v1/voices/{voice_id}/settings`      |
@@ -58,7 +58,7 @@ This is an open source Eleven Labs NodeJS package for converting text to speech 
 To install the Elevenlabs package, run the following command:
 
 ```shell
-npm install -g elevenlabs-node
+npm install elevenlabs-node
 ```
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ Function that converts text to speech and saves the audio file to the specified 
 
 @returns {Object} - An object containing the status of the operation.
 */
-const textToSpeech = async (apiKey, voiceID, fileName, textInput, stability, similarityBoost, modelId = "eleven_monolingual_v1") => {
+const textToSpeech = async (apiKey, voiceID, fileName, textInput, stability, similarityBoost, modelId) => {
 	try {
 
 		if (!apiKey || !voiceID || !fileName || !textInput) {

--- a/index.js
+++ b/index.js
@@ -18,9 +18,11 @@ Function that converts text to speech and saves the audio file to the specified 
 
 @param {number} similarityBoost - The similarity boost setting for the voice.
 
+@param {string} model_id - The model to use for the text-to-speech conversion. If null, it will use elevenlab's default model.
+
 @returns {Object} - An object containing the status of the operation.
 */
-const textToSpeech = async (apiKey, voiceID, fileName, textInput, stability, similarityBoost) => {
+const textToSpeech = async (apiKey, voiceID, fileName, textInput, stability, similarityBoost, model_id = "eleven_monolingual_v1") => {
 	try {
 
 		if (!apiKey || !voiceID || !fileName || !textInput) {
@@ -39,7 +41,8 @@ const textToSpeech = async (apiKey, voiceID, fileName, textInput, stability, sim
 				voice_settings: {
 					stability: stabilityValue,
 					similarity_boost: similarityBoostValue
-				}
+				},
+				model_id: model_id ? model_id : undefined
 			},
 			headers: {
 				'Accept': 'audio/mpeg',
@@ -74,9 +77,11 @@ Function that converts text to speech and returns a readable stream of the audio
 
 @param {number} similarityBoost - The similarity boost setting for the voice.
 
+@param {string} model_id - The model to use for the text-to-speech conversion. If null, it will use elevenlab's default model.
+
 @returns {Object} - A readable stream of the audio data.
 */
-const textToSpeechStream = async (apiKey, voiceID, textInput, stability, similarityBoost) => {
+const textToSpeechStream = async (apiKey, voiceID, textInput, stability, similarityBoost, model_id) => {
 	try {
 
 		if (!apiKey || !voiceID || !textInput) {
@@ -95,7 +100,8 @@ const textToSpeechStream = async (apiKey, voiceID, textInput, stability, similar
 				voice_settings: {
 					stability: stabilityValue,
 					similarity_boost: similarityBoostValue
-				}
+				},
+				model_id: model_id ? model_id : undefined
 			},
 			headers: {
 				'Accept': 'audio/mpeg',

--- a/index.js
+++ b/index.js
@@ -18,11 +18,11 @@ Function that converts text to speech and saves the audio file to the specified 
 
 @param {number} similarityBoost - The similarity boost setting for the voice.
 
-@param {string} model_id - The model to use for the text-to-speech conversion. If null, it will use elevenlab's default model.
+@param {string} modelId - The model to use for the text-to-speech conversion. If null, it will use elevenlab's default model.
 
 @returns {Object} - An object containing the status of the operation.
 */
-const textToSpeech = async (apiKey, voiceID, fileName, textInput, stability, similarityBoost, model_id = "eleven_monolingual_v1") => {
+const textToSpeech = async (apiKey, voiceID, fileName, textInput, stability, similarityBoost, modelId = "eleven_monolingual_v1") => {
 	try {
 
 		if (!apiKey || !voiceID || !fileName || !textInput) {
@@ -42,7 +42,7 @@ const textToSpeech = async (apiKey, voiceID, fileName, textInput, stability, sim
 					stability: stabilityValue,
 					similarity_boost: similarityBoostValue
 				},
-				model_id: model_id ? model_id : undefined
+				model_id: modelId ? modelId : undefined
 			},
 			headers: {
 				'Accept': 'audio/mpeg',
@@ -77,11 +77,11 @@ Function that converts text to speech and returns a readable stream of the audio
 
 @param {number} similarityBoost - The similarity boost setting for the voice.
 
-@param {string} model_id - The model to use for the text-to-speech conversion. If null, it will use elevenlab's default model.
+@param {string} modelId - The model to use for the text-to-speech conversion. If null, it will use elevenlab's default model.
 
 @returns {Object} - A readable stream of the audio data.
 */
-const textToSpeechStream = async (apiKey, voiceID, textInput, stability, similarityBoost, model_id) => {
+const textToSpeechStream = async (apiKey, voiceID, textInput, stability, similarityBoost, modelId) => {
 	try {
 
 		if (!apiKey || !voiceID || !textInput) {
@@ -101,7 +101,7 @@ const textToSpeechStream = async (apiKey, voiceID, textInput, stability, similar
 					stability: stabilityValue,
 					similarity_boost: similarityBoostValue
 				},
-				model_id: model_id ? model_id : undefined
+				model_id: modelId ? modelId : undefined
 			},
 			headers: {
 				'Accept': 'audio/mpeg',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elevenlabs-node",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "This is an open source Eleven Labs NodeJS package for converting text to speech using the Eleven Labs API",
   "main": "index.js",
   "scripts": {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -6,13 +6,14 @@ const fileName = 'audio.mp3';
 const textInput = 'mozzy is cool';
 const stability = '0.5';
 const similarityBoost = '0.5';
+const modelId = 'eleven_multilingual_v1';
 
 describe("Eleven Labs Node Unit Test", () => {
 
     // textToSpeech test
 	test("Test textToSpeech", async () => {
 		// Execute test
-		const response = await script.textToSpeech(apiKey, voiceID, fileName, textInput, stability, similarityBoost);
+		const response = await script.textToSpeech(apiKey, voiceID, fileName, textInput, stability, similarityBoost, modelId);
 
 		// Response check
 		expect(response.status).toEqual('ok');
@@ -21,7 +22,7 @@ describe("Eleven Labs Node Unit Test", () => {
         // textToSpeechStream test
 	test("Test textToSpeechStream", async () => {
 		// Execute test
-		const response = await script.textToSpeechStream(apiKey, voiceID, textInput, stability, similarityBoost);
+		const response = await script.textToSpeechStream(apiKey, voiceID, textInput, stability, similarityBoost, modelId);
 
 		// Response check
 		expect(!response).toBeFalsy();


### PR DESCRIPTION
Ran the jest test file, and all is still fine. By default, if no model is passed in, it should still be whatever the default model is to the folks at eleven labs. Added in this feature to use their new multi-lingual model.