### PR TITLE
feat: support for optional file downloading to get readableStream

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ ElevenLabs.prototype.textToSpeech = async function({
     similarityBoost,
     modelId,
     style,
-    speakerBoost
+    speakerBoost,
+    downloadFile=true
 }) {
     try {
         if (!fileName) {
@@ -89,6 +90,10 @@ ElevenLabs.prototype.textToSpeech = async function({
             },
             responseType: "stream",
         });
+
+        if(!downloadFile){
+            return response.data;
+        }
 
         response.data.pipe(fs.createWriteStream(fileName));
 


### PR DESCRIPTION
I was using this library when I wanted to consider saving the elevenlabs audio file in an S3 bucket.

The problem I encountered is that I was forced to download the file and then upload it.

With this small modification we can obtain with an optional parameter `downloadFile` in false the readableStream, that allows to upload directly to S3 this file without downloading it previously in our machine.